### PR TITLE
Fixed wrong version call in updates manual

### DIFF
--- a/content/docs/manual/updates.mdx
+++ b/content/docs/manual/updates.mdx
@@ -35,7 +35,7 @@ simplecloud migrate [version]
 
 This command guides you through any necessary migration steps for moving between major versions or handling significant changes that can't be applied automatically.
 
-For example, migrating to version 3.2:
+For example, migrating to version 3.0.0-beta.1:
 
 ```bash
 simplecloud migrate 3.0.0-beta.1


### PR DESCRIPTION
In the manual, on the "Updates" page, the version in the example sentence during migration is different from the one in the command. This fixes that.