### PR TITLE
clarify simpleCloud start command in documentation

### DIFF
--- a/content/docs/manual/setup/index.mdx
+++ b/content/docs/manual/setup/index.mdx
@@ -33,7 +33,7 @@ This command installs the SimpleCloud CLI and immediately runs the setup wizard 
 The setup wizard will automatically start SimpleCloud for you. If you need to start it manually, you can use the following command:
 
 ```bash
-simplecloud start
+simplecloud start cloud
 ```
 
 This command initiates the cloud and prepares it for use.


### PR DESCRIPTION
This pull request includes a minor update to the documentation to clarify the command for starting the Cloud.

* [`content/docs/manual/setup/index.mdx`](diffhunk://#diff-03e31b09cb4b87f078b28e62492e45e6954a7fd80439f11128bf6721bbe205f1L36-R36): Updated the command from `simplecloud start` to `simplecloud start cloud` to provide more precise instructions for initiating the cloud service.